### PR TITLE
Added a feedback if the search come up empty. 

### DIFF
--- a/bundles/irc-docsearch/start.php
+++ b/bundles/irc-docsearch/start.php
@@ -121,6 +121,12 @@ $observer = function($message)
 				$channel = $message->channel() ?: $message->sender->nick;
 				return Message::privmsg($channel, "Did someone ask for some docs? Here you go: " . $resultHref);
 			}
+			// give some feedback if the search lead to no results
+			else
+			{
+				$channel = $message->channel() ?: $message->sender->nick;
+				return Message::privmsg($channel, "Bummer! I couldn't find that doc for you. Sorry, I really tried...");
+			}
 
 
 		}


### PR DESCRIPTION
Hi Phil

Up till now Rommie would just stay silent if the doc search came up empty. Thats confusing because the user doesn't know if his !docs command was wrong formatted, rommie is down or what else went wrong.

I added an else case do give some simple feedback.
