### PR TITLE
Use link to docs for 4.1 upgrade

### DIFF
--- a/bundles/irc-general/config/triggers.php
+++ b/bundles/irc-general/config/triggers.php
@@ -21,5 +21,5 @@ return array(
     '!massassign'   => "Getting a MassAssignmentException? Find out how to protect your input at: http://wiki.laravel.io/FAQ_(Laravel_4)#MassAssignmentException",
     '!tableflip'    => "(╯°□°)╯︵ ┻━┻",
     '!xy'           => "It's difficult to discuss a solution without first understanding the problem. Please, explain the problem itself and not the solution that you have in mind. For more info on presenting your problem see !help. Thanks! Also see http://mywiki.wooledge.org/XyProblem",
-    '!41update'     => "If you're updating from 4.0.x to Laravel 4.1, make sure you follow the steps in https://github.com/laravel/laravel/blob/develop/upgrade.md to avoid common issues. This is due to necessary changes to the Laravel core to make things more awesome.",
+    '!41update'     => "If you're updating from 4.0.x to Laravel 4.1, make sure you follow the steps in http://laravel.com/docs/upgrade to avoid common issues. This is due to necessary changes to the Laravel core to make things more awesome.",
 );


### PR DESCRIPTION
That Github link doesn't lead anywhere anymore.
